### PR TITLE
Show error message

### DIFF
--- a/src/components/AHCLikeVisualizer.tsx
+++ b/src/components/AHCLikeVisualizer.tsx
@@ -21,6 +21,7 @@ const AHCLikeVisualizer: FC = () => {
 
   const [visualizerResult, setVisualizerResult] = useState<VisualizerResult>({
     svgString: '',
+    err: '',
     score: 0,
   });
 
@@ -62,11 +63,19 @@ const AHCLikeVisualizer: FC = () => {
         visualizerSettingInfo.turn
       );
       console.log(ret);
-      setVisualizerResult({ svgString: ret.svg, score: Number(ret.score) });
+      setVisualizerResult({
+        svgString: ret.svg,
+        err: ret.err,
+        score: Number(ret.score),
+      });
     } catch (e) {
       // visが失敗した場合にはエラーを出力する
       console.log(e);
-      setVisualizerResult({ svgString: 'invalid input or output', score: 0 });
+      setVisualizerResult({
+        svgString: 'invalid input or output',
+        err: '',
+        score: 0,
+      });
     }
   }, [
     visualizerSettingInfo.turn,
@@ -91,6 +100,7 @@ const AHCLikeVisualizer: FC = () => {
       <hr />
       <SvgViewer
         svgString={visualizerResult.svgString}
+        err={visualizerResult.err}
         score={visualizerResult.score}
       ></SvgViewer>
     </>

--- a/src/components/SvgViewer/index.tsx
+++ b/src/components/SvgViewer/index.tsx
@@ -2,13 +2,14 @@ import type { FC } from 'react';
 
 type SvgViewerProps = {
   svgString: string;
+  err: string;
   score: number;
 };
 
-const SvgViewer: FC<SvgViewerProps> = ({ svgString, score }) => {
+const SvgViewer: FC<SvgViewerProps> = ({ svgString, err, score }) => {
   return (
     <>
-      <div>score={score}</div>
+      <div>score={score} {err && <span style={{color: "red"}}>({err})</span>}</div>
       <div
         dangerouslySetInnerHTML={{
           __html: svgString,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,5 +8,6 @@ export type VisualizerSettingInfo = {
 
 export type VisualizerResult = {
   svgString: string;
+  err: string;
   score: number;
 };


### PR DESCRIPTION
`Ret` の `err` の内容を表示するようにしました。

エラーは赤文字で表示されます。エラーメッセージが空なら何もしません。  
添付画像の (not connected) の部分に相当します。

![Screenshot from 2024-01-09 08-29-51](https://github.com/yunix-kyopro/visualizer-template-public/assets/19629946/a78100d5-8746-4dec-af93-9379cd9707f2)
