### PR TITLE
TypeScriptの文法面に関する修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,15 @@
     "gif.js": "^0.2.0",
     "jszip": "^3.10.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.26.0"
   },
   "devDependencies": {
+    "@types/eslint": "~9.6.0",
+    "@types/eslint-config-prettier": "~6.11.3",
+    "@types/eslint-plugin-jsx-a11y": "~6.9.0",
+    "@types/gif.js": "~0.2.5",
+    "@types/lint-staged": "~13.2.2",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
     "@typescript-eslint/eslint-plugin": "^5.43.0",

--- a/src/components/FileUploader/index.tsx
+++ b/src/components/FileUploader/index.tsx
@@ -13,6 +13,23 @@ const FileUploader: FC<FileUploaderProps> = ({ setVisualizerSettingInfo }) => {
 
   const [files, setFiles] = useState<File[]>([]);
 
+  const setFileToOutput = (file: File) => {
+    const fileName = file.name;
+    const match = fileName.match(/(?:.*_)?(\d+)\..*/);
+    if (match !== null) {
+      const seed = parseInt(match[1], 10);
+      const fileReader = new FileReader();
+      fileReader.readAsText(file);
+      fileReader.onload = () => {
+        setVisualizerSettingInfo((prev) => ({
+          ...prev,
+          seed,
+          output: fileReader.result as string,
+        }));
+      };
+    }
+  };
+
   const onFolderUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files === null) return;
     const uploadedFiles = Array.from(e.target.files);
@@ -20,30 +37,22 @@ const FileUploader: FC<FileUploaderProps> = ({ setVisualizerSettingInfo }) => {
     if (uploadedFiles.length > 0) {
       setSelectDisabled(false);
       setFiles(uploadedFiles);
+      setFileToOutput(uploadedFiles[0]);
     }
   };
 
   const onSelectFile = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const fileName = e.target.value;
     const file = files.find((file) => file.name === e.target.value);
     if (file !== undefined) {
-      const match = fileName.match(/(?:.*_)?(\d+)\..*/);
-      if (match !== null) {
-        const seed = parseInt(match[1], 10);
-        const fileReader = new FileReader();
-        fileReader.readAsText(file);
-        fileReader.onload = () => {
-          setVisualizerSettingInfo((prev) => ({
-            ...prev,
-            seed,
-            output: fileReader.result as string,
-          }));
-        };
-      }
+      setFileToOutput(file);
     }
   };
 
-  /* eslint-disable react/no-unknown-property */
+  const otherAtt = {
+    directory: '',
+    webkitdirectory: '',
+  };
+
   return (
     <>
       <p>
@@ -55,16 +64,10 @@ const FileUploader: FC<FileUploaderProps> = ({ setVisualizerSettingInfo }) => {
             ))}
           </select>
         </label>
-        <input
-          type="file"
-          onChange={onFolderUpload}
-          directory="" // エディタでエラーが出るが気にしない
-          webkitdirectory=""
-        />
+        <input type="file" onChange={onFolderUpload} {...otherAtt} />
       </p>
     </>
   );
-  /* eslint-enable react/no-unknown-property */
 };
 
 export default FileUploader;

--- a/src/components/SaveButtons/index.tsx
+++ b/src/components/SaveButtons/index.tsx
@@ -15,7 +15,6 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
 
   const [animationButtonDisabled, setAnimationButtonDisabled] = useState(false);
 
-  /* eslint-disable */ // JavaScriptを書くことになるので、ESLintを無効化
   const onSavePng = useCallback(() => {
     const ret = vis(
       visualizerSettingInfo.input,
@@ -24,12 +23,12 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
     );
     const svg = new DOMParser()
       .parseFromString(ret.svg, 'image/svg+xml')
-      .getElementById('vis');
+      .getElementById('vis') as unknown as SVGSVGElement | null;
     if (svg === null) return;
     const canvas = document.createElement('canvas');
     canvas.width = svg.width.baseVal.value;
     canvas.height = svg.height.baseVal.value;
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d') as CanvasRenderingContext2D;
     const image = new Image();
     image.onload = function () {
       ctx.drawImage(image, 0, 0);
@@ -68,7 +67,7 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
         String(Math.round(50 + 50 * p)).padStart(3, ' ') + '% finished';
         */
     });
-    function add_frame(t) {
+    function addFrame(t: number) {
       /*
       save_gif.value =
         String(Math.round((50.0 * t) / max_turn)).padStart(3, ' ') +
@@ -81,7 +80,7 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
       const svgData = vis(input, output, t).svg;
       const svg = new DOMParser()
         .parseFromString(svgData, 'image/svg+xml')
-        .getElementById('vis');
+        .getElementById('vis') as unknown as SVGSVGElement | null;
       if (svg === null) return;
       const canvas = document.createElement('canvas');
       canvas.width = svg.width.baseVal.value;
@@ -91,13 +90,13 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
       const image = new Image();
       image.onload = function () {
         ctx.drawImage(image, 0, 0);
-        if (t == maxTurn) {
+        if (t === maxTurn) {
           gif.addFrame(canvas, { delay: 3000 });
         } else {
           gif.addFrame(canvas, { delay: delay });
         }
         if (t < maxTurn) {
-          add_frame(Math.min(t + step, maxTurn));
+          addFrame(Math.min(t + step, maxTurn));
         } else {
           gif.on('finished', function (blob) {
             const a = document.createElement('a');
@@ -116,7 +115,7 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
         'data:image/svg+xml;charset=utf-8;base64,' +
         btoa(unescape(encodeURIComponent(svgData)));
     }
-    add_frame(0);
+    addFrame(0);
   }, [
     visualizerSettingInfo.input,
     visualizerSettingInfo.output,
@@ -124,7 +123,6 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
     setAnimationButtonDescription,
     setAnimationButtonDisabled,
   ]);
-  /* eslint-enable */
 
   return (
     <>

--- a/src/components/SvgViewer/index.tsx
+++ b/src/components/SvgViewer/index.tsx
@@ -9,7 +9,9 @@ type SvgViewerProps = {
 const SvgViewer: FC<SvgViewerProps> = ({ svgString, err, score }) => {
   return (
     <>
-      <div>score={score} {err && <span style={{color: "red"}}>({err})</span>}</div>
+      <div>
+        score={score} {err && <span style={{ color: 'red' }}>({err})</span>}
+      </div>
       <div
         dangerouslySetInnerHTML={{
           __html: svgString,

--- a/src/components/TurnSlider/index.tsx
+++ b/src/components/TurnSlider/index.tsx
@@ -45,9 +45,9 @@ const TurnSlider: FC<TurnSliderProps> = ({
 
   const startSlider = useCallback(() => {
     setSliderContent('■');
-    const tickMilliSec =
+    const tickMilliseconds =
       (1000 * 300) / visualizerSettingInfo.maxTurn / sliderSpeed; // 1000 / sliderSpeed;
-    const id = setInterval(incrementTurn, tickMilliSec);
+    const id = setInterval(incrementTurn, tickMilliseconds);
     setIntervalId(id);
   }, [
     setIntervalId,
@@ -57,7 +57,7 @@ const TurnSlider: FC<TurnSliderProps> = ({
     incrementTurn,
   ]);
 
-  // turnがmaxturnになったらタイマーを止める
+  // turnがmaxTurnになったらタイマーを止める
   useEffect(() => {
     if (visualizerSettingInfo.turn === visualizerSettingInfo.maxTurn) {
       stopSlider();
@@ -77,7 +77,7 @@ const TurnSlider: FC<TurnSliderProps> = ({
       <p style={{ display: 'flex' }}>
         <input
           type="button"
-          className={styles.sliderButton}
+          className={styles.sliderButton} //eslint-disable-line
           value={sliderContent}
           onClick={onClickSliderButton}
         />
@@ -88,7 +88,7 @@ const TurnSlider: FC<TurnSliderProps> = ({
             min="1"
             max="60"
             value={sliderSpeed}
-            className={styles.speedSlider}
+            className={styles.speedSlider} //eslint-disable-line
             onChange={onChangeSliderSpeed}
           />
           fast
@@ -100,7 +100,7 @@ const TurnSlider: FC<TurnSliderProps> = ({
             value={visualizerSettingInfo.turn}
             min="0"
             max={visualizerSettingInfo.maxTurn}
-            className={styles.turnInput}
+            className={styles.turnInput} //eslint-disable-line
             onChange={onChangeTurn}
           />{' '}
         </label>
@@ -111,7 +111,7 @@ const TurnSlider: FC<TurnSliderProps> = ({
           min="0"
           max={visualizerSettingInfo.maxTurn}
           value={visualizerSettingInfo.turn}
-          className={styles.turnSlider}
+          className={styles.turnSlider} //eslint-disable-line
           onChange={onChangeTurn}
         />
       </p>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,2 @@
+declare module '*.css';
+declare module '*/rust';

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,7 +3,6 @@ import type { FC } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import InitWasm from 'components/InitWasm';
-import Home from 'components/templates/Home';
 
 const IndexRoutes: FC = () => {
   const { hash, pathname } = useLocation();
@@ -16,10 +15,7 @@ const IndexRoutes: FC = () => {
 
   return (
     <Routes>
-      <Route path="hoge">
-        <Route path="" element={<InitWasm />} />
-      </Route>
-      <Route path="/" element={<Home />} />
+      <Route path="/" element={<InitWasm />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,6 +839,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@remix-run/router@1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.19.0.tgz#745dbffbce67f05386d57ca22c51dfd85c979593"
+  integrity sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA==
+
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.24.tgz#8c7688559979f7079aacaf31aa881c3aa410b718"
@@ -891,6 +896,43 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/eslint-config-prettier@~6.11.3":
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/@types/eslint-config-prettier/-/eslint-config-prettier-6.11.3.tgz#319f53eeb5a8b50e702fa081a9fe39bf01df8c1d"
+  integrity sha512-3wXCiM8croUnhg9LdtZUJQwNcQYGWxxdOWDjPe1ykCqJFPVpzAKfs/2dgSoCtAvdPeaponcWPI7mPcGGp9dkKQ==
+
+"@types/eslint-plugin-jsx-a11y@~6.9.0":
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.9.0.tgz#477a6125401c1524cdbe48d13fe4120f80e3030b"
+  integrity sha512-5nw0sPyYGCsFibwjOXftxends8Nrh/JLgDtBWj6aJVcN14kHwy1yIy0o1MGLKfCcR27pvUFGgYG+hX2HSX16uA==
+  dependencies:
+    "@types/eslint" "*"
+
+"@types/eslint@*", "@types/eslint@~9.6.0":
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-9.6.0.tgz#51d4fe4d0316da9e9f2c80884f2c20ed5fb022ff"
+  integrity sha512-gi6WQJ7cHRgZxtkQEoyHMppPjq9Kxo5Tjn2prSKDSmZrCz8TZ3jSRCeTJm+WoM+oB0WG37bRqLzaaU3q7JypGg==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
+  integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
+
+"@types/events@*":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.3.tgz#a8ef894305af28d1fc6d2dfdfc98e899591ea529"
+  integrity sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==
+
+"@types/gif.js@~0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@types/gif.js/-/gif.js-0.2.5.tgz#c3c398c6d3eba4fe9385f055b41309fd1596d4f3"
+  integrity sha512-OdDQYh9v7td9ztjaooBSqjUBAyAuui2xwDDmQcyRLd6c9T0iWgkebAoCBEdEEBoZG3ekJE/6UnH63Dzq0S3bvw==
+  dependencies:
+    "@types/events" "*"
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -917,6 +959,11 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/json-schema@*":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -926,6 +973,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
+
+"@types/lint-staged@~13.2.2":
+  version "13.2.2"
+  resolved "https://registry.yarnpkg.com/@types/lint-staged/-/lint-staged-13.2.2.tgz#42aa5c12633c740568a68b39224722abf1f7fd9c"
+  integrity sha512-9c2ffPMJ1geob6yBmLuxzYye11HzKyA/I4dRZ8NfrPgY6SyzXt2SROD8vB3YjdPZJqqcu3WXsRvrY3PZbb720A==
 
 "@types/minimist@^1.2.0":
   version "1.2.2"
@@ -3986,6 +4038,21 @@ react-refresh@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
+
+react-router-dom@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.26.0.tgz#8debe13295c58605c04f93018d659a763245e58c"
+  integrity sha512-RRGUIiDtLrkX3uYcFiCIxKFWMcWQGMojpYZfcstc63A1+sSnVgILGIm9gNUA6na3Fm1QuPGSBQH2EMbAZOnMsQ==
+  dependencies:
+    "@remix-run/router" "1.19.0"
+    react-router "6.26.0"
+
+react-router@6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.26.0.tgz#d5af4c46835b202348ef2b7ddacd32a2db539fde"
+  integrity sha512-wVQq0/iFYd3iZ9H2l3N3k4PL8EEHcb0XlU2Na8nEwmiXgIUElEH6gaJDtUQxJ+JFzmIXaQjfdpcGWaM6IoQGxg==
+  dependencies:
+    "@remix-run/router" "1.19.0"
 
 react@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
# TypeScriptの文法面に関する修正

こんにちは。先日はお世話になりました。玻璃と申します。
今回は再び、pull requestを送らせていただきます。 (先程失敗したプルリクの通知が行っていたらすみません……)
主に、VSCode上で編集などをする際にひっかかるエラーなどを直しています。
機能面での向上も少しだけありますが、基本的には文法面を直しています。
ご検討いただけますと幸いです。

## 修正内容

### 1. folder uploadについて

恐らく、`FileUploader/index.tsx`のfolder uploadの部分は[これ](https://stackoverflow.com/a/55615518)を参考に書かれたと推察しておりますが、一番上の解答では(御記載の通り)エディタ上でerrorが出てしまいます。
そのコメントにerrorが出ない方法がありました。
それを用いて、folder uploadの部分を修正いたしました。

### 2. setFileToOutputの作成

同じく`FileUploader/index.tsx`について、`setFileToOutput`という関数を作成いたしました。
これは従来のビジュアライザだと、フォルダを選択しても何も表示されないため、その問題を解決するために作成いたしました。
これにより、フォルダをアップロードした時点で即時に先頭のファイルを表示することが可能となります。

### 3. global.d.tsの追加

従来は以下のようなコードで
`Cannot find module './index.module.css' or its corresponding type declarations.`
というwarningが出てしまっていました。

```tsx
import styles from './index.module.css';
```

これに`globals.d.ts`を作成してtype declarationを追加しました。
wasmのrustファイルについても同様の対応を行いました。

(先程取り下げたpull requestでは、

```tsx
import `./index.module.css`;
```

としていたのですが、それだとcssが読み込まれないらしくバグっていました。すいません。
よくよく他のファイルを見ると

```tsx
style.XXX
```

などの部分は

```tsx
//eslint-disable-line
```

で無理矢理無効化しており、先例に倣いました。ここは多分その時の変更もれだと思います。)

### 4. 明示的な型変換

`SaveButtons/index.tsx`において、`svg`の型が`HTMLElement`であるため、`Property 'width' does not exist on type 'HTMLElement'`というエラーが出てしまっていました。(もともとはエラーの抑制コードがあったのですが、仕様違い?で自分の環境だとそれが効いていませんでした。なので根本から直しています。)

DOMParserからインスタンスを生成している為、正確に記述することは困難だと思っているのですが、一応`as`を用いて型変換を行いました。もしかしたらこの変更は改悪かも知れませんが、取得される対象が常にsvgであることはこのビジュアライザを開発される方にとってほぼ確実と言ってよいと思いますので、この変更を行いました。

`canvas.getContext('2d') as CanvasRenderingContext2D`に関しても同様の理由で型変換を行いました。

### 5. 型の追加

同じく`SaveButtons/index.tsx`において、
`function add_frame(t)`となっていたのを、
`function addFrame(t: number)`に変更いたしました。

(ESLintでは関数名にsnake_caseを使うことが禁止されているため、camelCaseに変更してもいます。)

### 6. routerの設定

`src/routes/index.tsx`において、

```tsx
import Home from 'components/templates/Home';
```

というコードがあったのですが、`components`フォルダに`templates`フォルダが存在しないので、エラーが出てしまっていました。
恐らくなのですが、viteか何かでデフォルト構成を読み込んで、いらないものを削除していった際に、`templates`なら不要だろうということで削除したなどではないかと推察しております。

私はあまりこのRouteについては詳しくないのですが、十中八九これで大丈夫というものに変更しました。
(ここに関してはあんまり自信がありません、すいません。ただ、ここが効いてくるのはGithub Pagesなどにデプロイする際などである為、普通は問題ないと思います。) (今後もしかしたらデプロイなどを私の方でする機会があるので、もしそれで問題が生じたらまたpull requestなどを出して修正するかも知れません。)

### 7. package.jsonへreact-router-domの追加

従来のコードでは、`yarn build`を行った際に、以下のようなエラーも出てしまっていました。

```tsx
src/routes/index.tsx:3:54 - error TS2307: Cannot find module 'react-router-dom' or its corresponding type declarations.

3 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
```

これを解決するために、`package.json`に`react-router-dom`などを追加いたしました。

[参考リンク](https://stackoverflow.com/questions/53914013/failed-to-compile-module-not-found-cant-resolve-react-router-dom)

`@types/eslint`などはそれのおまけでついてきているだけです。

### 8. 非常に軽微なスペリングの修正など

vscodeのspell checkerに引っかかった箇所を修正いたしました。
また、フォーマットもれがあったのでそこも修正いたしました。

## コミット内容

以上の修正内容を主に順番にコミットしています。
一部コミット内容が不適と判断された場合は、当該コミットを削除しやすくなっています。

## 簡易的なテスト

この修正を行った上で、[サイト](https://yunix-kyopro.hatenablog.com/entry/2023/12/17/150534)にあるようにrustをyukicoder score contest 2用に変更して、ビジュアライザを実行しました。

結果、特に問題なく動作すること、また、a1.outなどのように正規表現にマッチする場合には、そのファイルが選択せずとも表示されることを確認しました。
(元の実装を残すように変更したので、a.outなどだと正規表現にマッチせずOutputは更新されません。この辺はAHCの普段のビジュアライザとは少し勝手が違うかも知れません)

---

以上、ご確認いただけますと幸いです。
何か問題があれば、お知らせください。

(ちなみにこれは余談ですが、今回yunix様のビジュアライザは私の大学でしている研究目的で使わせて頂いてます。(最近はめっきり競プロから遠ざかっていますが……) このビジュアライザはめちゃくちゃ扱いやすく、またMIT LICENSEで研究のソースコード公開の際にも楽で、本当に助かっています。ありがとうございます。 もしかしたら1年後あたりに論文の謝辞に名前かハンネを載せさせてもらえないかとお伺いする機会があるかも知れません。本当にありがとうございます。)
