### PR TITLE
問題番号を選択できる場所を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^29.5.0",
     "lint-staged": "^13.2.2",
-    "prettier": "^2.8.8",
+    "prettier": "^3.5.2",
     "simple-git-hooks": "^2.8.1",
     "stylelint": "^15.6.1",
     "stylelint-config-recess-order": "^4.0.0",

--- a/src/components/AHCLikeVisualizer.tsx
+++ b/src/components/AHCLikeVisualizer.tsx
@@ -17,6 +17,7 @@ const AHCLikeVisualizer: FC = () => {
       seed: 0,
       turn: 0,
       maxTurn: 0,
+      problemId: 'A',
     });
 
   const [visualizerResult, setVisualizerResult] = useState<VisualizerResult>({
@@ -26,15 +27,18 @@ const AHCLikeVisualizer: FC = () => {
   });
 
   useEffect(() => {
-    const inputText = gen(visualizerSettingInfo.seed);
+    const inputText = gen(
+      visualizerSettingInfo.seed,
+      visualizerSettingInfo.problemId,
+    );
     setVisualizerSettingInfo((prev) => ({ ...prev, input: inputText }));
-  }, [visualizerSettingInfo.seed]);
+  }, [visualizerSettingInfo.seed, visualizerSettingInfo.problemId]);
 
   useEffect(() => {
     try {
       const maxTurn = getMaxTurn(
         visualizerSettingInfo.input,
-        visualizerSettingInfo.output
+        visualizerSettingInfo.output,
       );
       setVisualizerSettingInfo((prev) => ({
         ...prev,
@@ -60,7 +64,7 @@ const AHCLikeVisualizer: FC = () => {
       const ret = vis(
         visualizerSettingInfo.input,
         visualizerSettingInfo.output,
-        visualizerSettingInfo.turn
+        visualizerSettingInfo.turn,
       );
       console.log(ret);
       setVisualizerResult({

--- a/src/components/InputOutput/hooks.ts
+++ b/src/components/InputOutput/hooks.ts
@@ -4,25 +4,27 @@ import { gen } from '../../../public/wasm/rust';
 export const useDownloadInput = (): {
   downloadInput: (
     seed: number,
+    problemNumber: string,
     downloadCases: number,
-    setButtonText: (content: string) => void
+    setButtonText: (content: string) => void,
   ) => void;
 } => {
   const downloadInput = (
     seed: number,
+    problemId: string,
     downloadCases: number,
-    setButtonText: (content: string) => void
+    setButtonText: (content: string) => void,
   ): void => {
     const zip = new JSZip();
     for (let i = 0; i < downloadCases; i++) {
-      const inputString = gen(seed + i);
+      const inputString = gen(seed + i, problemId);
       zip.file((seed + i).toString().padStart(4, '0') + '.txt', inputString);
     }
     /* eslint-disable*/
     zip
       .generateAsync({ type: 'blob' }, (e) => {
         setButtonText(
-          String(Math.round(e.percent)).padStart(3, ' ') + '% finished'
+          String(Math.round(e.percent)).padStart(3, ' ') + '% finished',
         );
       })
       .then((blob) => {

--- a/src/components/InputOutput/index.module.css
+++ b/src/components/InputOutput/index.module.css
@@ -1,3 +1,7 @@
-.textArea{
-    width: 650px;
+.textArea {
+  width: 650px;
+}
+
+.leftMargin {
+  margin-left: 10px;
 }

--- a/src/components/InputOutput/index.tsx
+++ b/src/components/InputOutput/index.tsx
@@ -40,12 +40,18 @@ const InputOutput: FC<InputOutputProps> = ({
     }));
   };
 
+  const onChangeProblemId = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setVisualizerSettingInfo((prev) => ({
+      ...prev,
+      problemId: e.target.value,
+    }));
+  };
+
   return (
     <>
       <div>
         <label>
           Seed:
-          <br />
           <input
             type="number"
             value={visualizerSettingInfo.seed}
@@ -54,7 +60,9 @@ const InputOutput: FC<InputOutputProps> = ({
             onChange={onChangeSeed}
           />
         </label>
-        <label>
+        <label
+          className={styles.leftMargin} //eslint-disable-line
+        >
           #cases:
           <input
             type="number"
@@ -73,11 +81,28 @@ const InputOutput: FC<InputOutputProps> = ({
           onClick={() => {
             downloadInput(
               visualizerSettingInfo.seed,
+              visualizerSettingInfo.problemId,
               downloadCases,
-              setButtonText
+              setButtonText,
             );
           }}
         />
+
+        <label
+          className={styles.leftMargin} //eslint-disable-line
+        >
+          問題番号:
+          <select
+            value={visualizerSettingInfo.problemId}
+            onChange={(e) => {
+              onChangeProblemId(e);
+            }}
+          >
+            <option value="A">A</option>
+            <option value="B">B</option>
+            <option value="C">C</option>
+          </select>
+        </label>
       </div>
       <div>
         <label>

--- a/src/components/SaveButtons/index.tsx
+++ b/src/components/SaveButtons/index.tsx
@@ -10,7 +10,7 @@ type SvgViewerProps = {
 
 const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
   const [animationButtonDescription, setAnimationButtonDescription] = useState(
-    'Save as Animation GIF'
+    'Save as Animation GIF',
   );
 
   const [animationButtonDisabled, setAnimationButtonDisabled] = useState(false);
@@ -19,7 +19,7 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
     const ret = vis(
       visualizerSettingInfo.input,
       visualizerSettingInfo.output,
-      visualizerSettingInfo.turn
+      visualizerSettingInfo.turn,
     );
     const svg = new DOMParser()
       .parseFromString(ret.svg, 'image/svg+xml')
@@ -60,7 +60,7 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
     });
     gif.on('progress', function (p) {
       setAnimationButtonDescription(
-        String(Math.round(50 + 50 * p)).padStart(3, ' ') + '% finished'
+        String(Math.round(50 + 50 * p)).padStart(3, ' ') + '% finished',
       );
       /*
       save_gif.value =
@@ -75,7 +75,8 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
         */
 
       setAnimationButtonDescription(
-        String(Math.round((50.0 * t) / maxTurn)).padStart(3, ' ') + '% finished'
+        String(Math.round((50.0 * t) / maxTurn)).padStart(3, ' ') +
+          '% finished',
       );
       const svgData = vis(input, output, t).svg;
       const svg = new DOMParser()
@@ -93,7 +94,7 @@ const SvgViewer: FC<SvgViewerProps> = ({ visualizerSettingInfo }) => {
         if (t === maxTurn) {
           gif.addFrame(canvas, { delay: 3000 });
         } else {
-          gif.addFrame(canvas, { delay: delay });
+          gif.addFrame(canvas, { delay });
         }
         if (t < maxTurn) {
           addFrame(Math.min(t + step, maxTurn));

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type VisualizerSettingInfo = {
   seed: number;
   turn: number;
   maxTurn: number;
+  problemId: string;
 };
 
 export type VisualizerResult = {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,8 +1,8 @@
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn gen(seed: i32) -> String {
-    "".to_string()
+pub fn gen(seed: i32, problemId: String) -> String {
+    problemId
 }
 
 #[wasm_bindgen(getter_with_clone)]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3972,10 +3972,10 @@ prettier@*:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.4.2.tgz#a5ce1fb522a588bf2b78ca44c6e6fe5aa5a2b13f"
   integrity sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==
 
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.2.tgz#d066c6053200da0234bf8fa1ef45168abed8b914"
+  integrity sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==
 
 pretty-format@^29.5.0:
   version "29.5.0"


### PR DESCRIPTION
昨年のマスターズ決勝では問題番号がA~Cまで与えられ、それぞれについて傾向の異なる問題が出題されました。
今年も同様の方式で3問の問題が出題されるのではないかと推測されます。

そこで、問題番号を選択する場所を作り、マスターズにおいて便利なように改修を行いました。
この機能が必要ない場合でも単純に問題番号を無視をすれば良いため、mainブランチに入れることにします。

<img width="572" alt="スクリーンショット 2025-02-28 21 32 05" src="https://github.com/user-attachments/assets/ca03be41-9c1a-407d-8829-7866b454c37a" />
